### PR TITLE
Add installer plugin

### DIFF
--- a/conda_pypi/installer.py
+++ b/conda_pypi/installer.py
@@ -1,0 +1,21 @@
+from typing import Iterable
+
+from conda.plugins.types import InstallerBase
+
+from .main import run_pip_install
+
+class PipInstaller(InstallerBase):
+    def install(self, prefix, specs, *args, **kwargs) -> Iterable[str]:
+        """Install packages into an environment"""
+        run_pip_install(
+            prefix=prefix,
+            args=specs,
+        )
+
+    def dry_run(self, prefix, specs, *args, **kwargs) -> Iterable[str]:
+        """Do a dry run of the environment install"""
+        run_pip_install(
+            prefix=prefix,
+            args=specs,
+            dry_run=True,
+        )

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -135,7 +135,7 @@ def run_pip_install(
     command.extend(args)
 
     logger.info("pip install command: %s", command)
-    process = run(command, capture_output=capture_output or check, text=capture_output or check)
+    process = run(command, text=capture_output or check)
     if check and process.returncode:
         raise CondaError(
             f"Failed to run pip:\n"

--- a/conda_pypi/plugin.py
+++ b/conda_pypi/plugin.py
@@ -1,6 +1,7 @@
 from conda import plugins
 
 from . import cli
+from .installer import PipInstaller
 from .main import ensure_target_env_has_externally_managed
 
 
@@ -30,4 +31,13 @@ def conda_post_commands():
         name="conda-pypi-post-install-create",
         action=cli.install.post_command,
         run_for={"install", "create"},
+    )
+
+
+@plugins.hookimpl
+def conda_installers():
+    yield plugins.CondaInstaller(
+        name="pip",
+        types=("pip",),
+        installer=PipInstaller,
     )


### PR DESCRIPTION
Depends https://github.com/conda/conda/pull/14794 and https://github.com/conda/conda/compare/main...soapy1:conda:experiment-installer-hooks-just-install?expand=1

This PR implements the conda installer plugin hooks. So, installing this plugin into a conda environemnt allows conda to install pip packages definied in an `environment.yaml` into an environment using `conda-pypi`.

To test this out:
* check out the conda branch https://github.com/conda/conda/compare/main...soapy1:conda:experiment-installer-hooks-just-install?expand=1
* install conda-pypi in your development conda environment  (`python -m pip install -e ../path/to/conda-pypi`
* create a test `environment.yaml` with pip packages. For example:
```
name: pip
dependencies:
  - pip
  - pip:
    - flask 
```
* install the environment `conda env create --file environment.yaml`