### PR TITLE
Install converted conda packages

### DIFF
--- a/conda_pypi/cli/install.py
+++ b/conda_pypi/cli/install.py
@@ -7,6 +7,7 @@ from conda.models.match_spec import MatchSpec
 
 from conda_pypi import convert_tree
 from conda_pypi.downloader import get_package_finder
+from conda_pypi.main import run_conda_install
 
 
 def configure_parser(parser: _SubParsersAction) -> None:
@@ -89,5 +90,9 @@ def execute(args: Namespace) -> int:
     # Convert package strings to MatchSpec objects
     match_specs = [MatchSpec(pkg) for pkg in args.packages]
     converter.convert_tree(match_specs)
+    channel_url = converter.repo.as_uri()
+
+    # Install converted packages to current conda environment
+    run_conda_install(prefix_path, match_specs, channels=[channel_url], override_channels=False)
 
     return 0

--- a/conda_pypi/cli/install.py
+++ b/conda_pypi/cli/install.py
@@ -93,7 +93,7 @@ def execute(args: Namespace) -> int:
     channel_url = converter.repo.as_uri()
 
     # Install converted packages to current conda environment
-    run_conda_install(
+    return run_conda_install(
         prefix_path,
         match_specs,
         channels=[channel_url],
@@ -103,5 +103,3 @@ def execute(args: Namespace) -> int:
         verbosity=args.verbosity,
         dry_run=args.dry_run,
     )
-
-    return 0

--- a/conda_pypi/cli/install.py
+++ b/conda_pypi/cli/install.py
@@ -93,6 +93,15 @@ def execute(args: Namespace) -> int:
     channel_url = converter.repo.as_uri()
 
     # Install converted packages to current conda environment
-    run_conda_install(prefix_path, match_specs, channels=[channel_url], override_channels=False)
+    run_conda_install(
+        prefix_path,
+        match_specs,
+        channels=[channel_url],
+        override_channels=False,
+        yes=args.yes,
+        quiet=args.quiet,
+        verbosity=args.verbosity,
+        dry_run=args.dry_run,
+    )
 
     return 0

--- a/conda_pypi/convert_tree.py
+++ b/conda_pypi/convert_tree.py
@@ -15,6 +15,7 @@ from conda.base.context import context
 from conda.common.path import get_python_short_path
 from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
+from conda.models.records import PrefixRecord
 from conda_libmamba_solver.solver import (
     LibMambaIndexHelper,
     LibMambaSolver,
@@ -96,7 +97,24 @@ class ConvertTree:
     def default_package_finder(self):
         return get_package_finder(self.prefix)
 
-    def convert_tree(self, requested: List[MatchSpec], max_attempts=20):
+    def convert_tree(self, requested: List[MatchSpec], max_attempts: int = 20) -> tuple[tuple[PrefixRecord], tuple[PrefixRecord]] | None:
+        """
+        Preform a solve on the list of requested packages and converts the full dependency
+        tree to conda packages if required. The converted packages will be stored in the
+        local conda-pypi channel.
+
+        Args:
+            requested: List[MatchSpec]: The list of requested packages.
+            max_attempts: max number of times to try to execute the solve.
+
+        Returns:
+            tuple[PackageRef], tuple[PackageRef]:
+                A two-tuple of PackageRef sequences.  The first is the group of packages to
+                remove from the environment, in sorted dependency order from leaves to roots.
+                The second is the group of packages to add to the environment, in sorted
+                dependency order from roots to leaves.
+
+        """
         (self.repo / "noarch").mkdir(parents=True, exist_ok=True)
         if not (self.repo / "noarch" / "repodata.json").exists():
             update_index(self.repo)

--- a/conda_pypi/convert_tree.py
+++ b/conda_pypi/convert_tree.py
@@ -101,7 +101,7 @@ class ConvertTree:
 
     def convert_tree(
         self, requested: List[MatchSpec], max_attempts: int = 20
-    ) -> tuple[tuple[PrefixRecord], tuple[PrefixRecord]] | None:
+    ) -> tuple[tuple[PrefixRecord, ...], tuple[PrefixRecord, ...]] | None:
         """
         Preform a solve on the list of requested packages and converts the full dependency
         tree to conda packages if required. The converted packages will be stored in the
@@ -112,7 +112,7 @@ class ConvertTree:
             max_attempts: max number of times to try to execute the solve.
 
         Returns:
-            tuple[PackageRef], tuple[PackageRef]:
+            tuple[PackageRef, ...], tuple[PackageRef, ...]:
                 A two-tuple of PackageRef sequences.  The first is the group of packages to
                 remove from the environment, in sorted dependency order from leaves to roots.
                 The second is the group of packages to add to the environment, in sorted

--- a/conda_pypi/convert_tree.py
+++ b/conda_pypi/convert_tree.py
@@ -108,15 +108,14 @@ class ConvertTree:
         local conda-pypi channel.
 
         Args:
-            requested: List[MatchSpec]: The list of requested packages.
+            requested: The list of requested packages.
             max_attempts: max number of times to try to execute the solve.
 
         Returns:
-            tuple[PackageRef, ...], tuple[PackageRef, ...]:
-                A two-tuple of PackageRef sequences.  The first is the group of packages to
-                remove from the environment, in sorted dependency order from leaves to roots.
-                The second is the group of packages to add to the environment, in sorted
-                dependency order from roots to leaves.
+            A two-tuple of PackageRef sequences.  The first is the group of packages to
+            remove from the environment, in sorted dependency order from leaves to roots.
+            The second is the group of packages to add to the environment, in sorted
+            dependency order from roots to leaves.
 
         """
         (self.repo / "noarch").mkdir(parents=True, exist_ok=True)

--- a/conda_pypi/convert_tree.py
+++ b/conda_pypi/convert_tree.py
@@ -97,7 +97,9 @@ class ConvertTree:
     def default_package_finder(self):
         return get_package_finder(self.prefix)
 
-    def convert_tree(self, requested: List[MatchSpec], max_attempts: int = 20) -> tuple[tuple[PrefixRecord], tuple[PrefixRecord]] | None:
+    def convert_tree(
+        self, requested: List[MatchSpec], max_attempts: int = 20
+    ) -> tuple[tuple[PrefixRecord], tuple[PrefixRecord]] | None:
         """
         Preform a solve on the list of requested packages and converts the full dependency
         tree to conda packages if required. The converted packages will be stored in the

--- a/conda_pypi/convert_tree.py
+++ b/conda_pypi/convert_tree.py
@@ -1,6 +1,7 @@
 """
 Convert a dependency tree from pypi into .conda packages
 """
+from __future__ import annotations
 
 import logging
 import pathlib

--- a/conda_pypi/convert_tree.py
+++ b/conda_pypi/convert_tree.py
@@ -1,6 +1,7 @@
 """
 Convert a dependency tree from pypi into .conda packages
 """
+
 from __future__ import annotations
 
 import logging

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -9,7 +9,7 @@ from csv import reader as csv_reader
 from email.parser import HeaderParser
 from logging import getLogger
 from pathlib import Path
-import runpy
+from runpy import run_module
 from subprocess import run, CompletedProcess
 from tempfile import NamedTemporaryFile
 from typing import Any, Iterable, Literal
@@ -45,7 +45,7 @@ def run_conda_cli(*cli_args, **env_kwargs):
         old_env = os.environ.copy()
         os.environ.update(env_kwargs)
         sys.argv = command
-        runpy.run_module("conda", run_name="__main__")
+        run_module("conda", run_name="__main__")
     except SystemExit as exc:
         logger.info("conda command system exit:", exc_info=True)
         return exc.code

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -14,11 +14,13 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Iterable, Literal
 
 from conda.base.context import context
+from conda.cli.python_api import run_command
 from conda.plugins.prefix_data_loaders.pypi.pkg_format import PythonDistribution
 from conda.core.prefix_data import PrefixData
-from conda.exceptions import InvalidVersionSpec
+from conda.exceptions import CondaSystemExit, InvalidVersionSpec
 from conda.gateways.disk.read import compute_sum
 from conda.models.enums import PackageType
+from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord
 from conda.exceptions import CondaError
 from packaging.requirements import Requirement
@@ -33,6 +35,52 @@ from conda_pypi.python_paths import (
 
 logger = getLogger(f"conda.{__name__}")
 HERE = Path(__file__).parent.resolve()
+
+
+def run_conda_install(
+    prefix: Path,
+    specs: Iterable[MatchSpec],
+    dry_run: bool = False,
+    quiet: bool = False,
+    verbosity: int = 0,
+    force_reinstall: bool = False,
+    yes: bool = False,
+    json: bool = False,
+    channels: Iterable[str] = None,
+    override_channels: bool = False,
+) -> int:
+    if not specs:
+        return 0
+
+    command = ["install", "--prefix", str(prefix)]
+    if dry_run:
+        command.append("--dry-run")
+    if quiet:
+        command.append("--quiet")
+    if verbosity:
+        command.append("-" + ("v" * verbosity))
+    if force_reinstall:
+        command.append("--force-reinstall")
+    if yes:
+        command.append("--yes")
+    if json:
+        command.append("--json")
+    if channels:
+        for channel in channels:
+            command.append("--channel")
+            command.append(channel)
+    if override_channels:
+        command.append("--override-channels")
+
+    command.extend(str(spec) for spec in specs)
+
+    print(command)
+    logger.info("conda install command: conda %s", command)
+    try:
+        *_, retcode = run_command(*command, stdout=None, stderr=None, use_exception_handler=True)
+    except CondaSystemExit:
+        return 0
+    return retcode
 
 
 def run_pip_install(

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -9,12 +9,12 @@ from csv import reader as csv_reader
 from email.parser import HeaderParser
 from logging import getLogger
 from pathlib import Path
-from runpy import run_module
 from subprocess import run, CompletedProcess
 from tempfile import NamedTemporaryFile
 from typing import Any, Iterable, Literal
 
 from conda.base.context import context
+from conda.cli.main import main_subshell
 from conda.plugins.prefix_data_loaders.pypi.pkg_format import PythonDistribution
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import InvalidVersionSpec
@@ -38,22 +38,14 @@ HERE = Path(__file__).parent.resolve()
 
 
 def run_conda_cli(*cli_args, **env_kwargs) -> int:
-    command = ["conda", *cli_args]
-    logger.info("conda command: %s", command)
+    logger.info("conda command: '%s'", " ".join(cli_args))
     try:
-        old_argv = sys.argv[:]
-        old_env = os.environ.copy()
-        os.environ.update(env_kwargs)
-        sys.argv = command
-        run_module("conda", run_name="__main__")
+        main_subshell(*cli_args)
     except SystemExit as exc:
         logger.info("conda command system exit:", exc_info=True)
         return exc.code
     else:
         return 0
-    finally:
-        sys.argv[:] = old_argv[:]
-        os.environ = old_env
 
 
 def run_conda_install(

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -37,7 +37,7 @@ logger = getLogger(f"conda.{__name__}")
 HERE = Path(__file__).parent.resolve()
 
 
-def run_conda_cli(*cli_args, **env_kwargs):
+def run_conda_cli(*cli_args, **env_kwargs) -> int:
     command = ["conda", *cli_args]
     logger.info("conda command: %s", command)
     try:
@@ -65,7 +65,7 @@ def run_conda_install(
     force_reinstall: bool = False,
     yes: bool = False,
     json: bool = False,
-    channels: Iterable[str] = None,
+    channels: Iterable[str] = (),
     override_channels: bool = False,
 ) -> int:
     command = ["install", "--prefix", str(prefix)]

--- a/conda_pypi/main.py
+++ b/conda_pypi/main.py
@@ -17,7 +17,7 @@ from typing import Any, Iterable, Literal
 from conda.base.context import context
 from conda.plugins.prefix_data_loaders.pypi.pkg_format import PythonDistribution
 from conda.core.prefix_data import PrefixData
-from conda.exceptions import CondaSystemExit, InvalidVersionSpec
+from conda.exceptions import InvalidVersionSpec
 from conda.gateways.disk.read import compute_sum
 from conda.models.enums import PackageType
 from conda.models.match_spec import MatchSpec

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -42,11 +42,12 @@ def test_index_urls(tmp_env, conda_cli, pypi_local_index):
             "pypi",
             "--prefix",
             prefix,
+             "--yes",
             "install",
             "--override-channels",
             "--index-url",
             pypi_local_index,
-            "demo_package",
+            "demo-package",
         )
         print(out)
         print(err, file=sys.stderr)

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -42,7 +42,7 @@ def test_index_urls(tmp_env, conda_cli, pypi_local_index):
             "pypi",
             "--prefix",
             prefix,
-             "--yes",
+            "--yes",
             "install",
             "--override-channels",
             "--index-url",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -14,21 +14,20 @@ from conda.testing.fixtures import TmpEnvFixture, CondaCLIFixture
 from conda_pypi.python_paths import get_env_python, get_env_site_packages
 
 
-@pytest.mark.skip(reason="Migrating to alternative install method using conda pupa")
 @pytest.mark.parametrize(
     "pypi_spec,conda_spec,channel",
     [
         ("numpy", "", "conda-forge"),
         ("numpy=1.20", "", "conda-forge"),
-        # build was originally published as build in conda-forge
-        # and later renamed to python-build; conda-forge::build is
-        # only available til 0.7, but conda-forge::python-build has 1.x
-        ("build>=1", "python-build>=1", "conda-forge"),
-        # ib-insync is only available with dashes, not with underscores
-        ("ib_insync", "ib-insync", "conda-forge"),
-        # these won't be ever published in conda-forge, I guess
-        ("aaargh", None, "pypi"),
-        ("5-exercise-upload-to-pypi", None, "pypi"),
+        # # build was originally published as build in conda-forge
+        # # and later renamed to python-build; conda-forge::build is
+        # # only available til 0.7, but conda-forge::python-build has 1.x
+        # ("build>=1", "python-build>=1", "conda-forge"),
+        # # ib-insync is only available with dashes, not with underscores
+        # ("ib_insync", "ib-insync", "conda-forge"),
+        # # these won't be ever published in conda-forge, I guess
+        # ("aaargh", None, "pypi"),
+        # ("5-exercise-upload-to-pypi", None, "pypi"),
     ],
 )
 def test_conda_pypi_install(
@@ -37,16 +36,9 @@ def test_conda_pypi_install(
     pypi_spec: str,
     conda_spec: str,
     channel: str,
-    backend: str,
 ):
-    # Skip grayskull tests on Python < 3.10 due to grayskull dependency issues
-    if backend == "grayskull" and sys.version_info < (3, 10):
-        pytest.skip(
-            "Grayskull requires Python 3.10+ due to union type annotations in dependencies"
-        )
-
     conda_spec = conda_spec or pypi_spec
-    with tmp_env("python=3.9", "pip") as prefix:
+    with tmp_env("python=3.9") as prefix:
         out, err, rc = conda_cli(
             "pypi",
             "-p",
@@ -89,7 +81,7 @@ def test_spec_normalization(
             print(out)
             print(err, file=sys.stderr)
             assert rc == 0
-            assert "All packages are already installed." in out + err
+            assert "All requested packages already installed." in out
 
 
 @pytest.mark.skip(reason="Migrating to alternative install method using conda pupa")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,50 @@
+import sys
+
+from conda_pypi.main import run_conda_cli, run_conda_install
+
+
+def test_run_conda_cli(mocker):
+    mock = mocker.patch("conda_pypi.main.run_module")
+    
+    old_sys_argv = sys.argv
+    run_conda_cli()
+
+    # Ensure conda module is called
+    mock.assert_called_once_with("conda", run_name="__main__")
+
+    # Ensure args are restored
+    assert sys.argv == old_sys_argv
+    
+
+def test_run_conda_install_basic(mocker):
+    mock = mocker.patch("conda_pypi.main.run_conda_cli")
+    
+    run_conda_install(
+        prefix="idontexist",
+        specs=["numpy",]
+    )
+
+    # Ensure conda module is called
+    mock.assert_called_once_with("install", "--prefix", "idontexist", "numpy")
+
+
+def test_run_conda_install(mocker):
+    mock = mocker.patch("conda_pypi.main.run_conda_cli")
+    
+    run_conda_install(
+        prefix="idontexist",
+        specs=["numpy","scipy"],
+        dry_run=True,
+        quiet=True,
+        verbosity=2,
+        force_reinstall=True,
+        yes=True,
+        json=True,
+        channels=["mychannel", "abc"],
+        override_channels=True,
+    )
+
+    # Ensure conda module is called
+    mock.assert_called_once_with(
+        "install", "--prefix", "idontexist", "--dry-run", "--quiet", "-vv", "--force-reinstall", "--yes", "--json", "--channel", "mychannel", "--channel" , "abc", "--override-channels", "numpy", "scipy"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from conda_pypi.main import run_conda_cli, run_conda_install
 
 def test_run_conda_cli(mocker):
     mock = mocker.patch("conda_pypi.main.run_module")
-    
+
     old_sys_argv = sys.argv
     run_conda_cli()
 
@@ -14,14 +14,16 @@ def test_run_conda_cli(mocker):
 
     # Ensure args are restored
     assert sys.argv == old_sys_argv
-    
+
 
 def test_run_conda_install_basic(mocker):
     mock = mocker.patch("conda_pypi.main.run_conda_cli")
-    
+
     run_conda_install(
         prefix="idontexist",
-        specs=["numpy",]
+        specs=[
+            "numpy",
+        ],
     )
 
     # Ensure conda module is called
@@ -30,10 +32,10 @@ def test_run_conda_install_basic(mocker):
 
 def test_run_conda_install(mocker):
     mock = mocker.patch("conda_pypi.main.run_conda_cli")
-    
+
     run_conda_install(
         prefix="idontexist",
-        specs=["numpy","scipy"],
+        specs=["numpy", "scipy"],
         dry_run=True,
         quiet=True,
         verbosity=2,
@@ -46,5 +48,20 @@ def test_run_conda_install(mocker):
 
     # Ensure conda module is called
     mock.assert_called_once_with(
-        "install", "--prefix", "idontexist", "--dry-run", "--quiet", "-vv", "--force-reinstall", "--yes", "--json", "--channel", "mychannel", "--channel" , "abc", "--override-channels", "numpy", "scipy"
+        "install",
+        "--prefix",
+        "idontexist",
+        "--dry-run",
+        "--quiet",
+        "-vv",
+        "--force-reinstall",
+        "--yes",
+        "--json",
+        "--channel",
+        "mychannel",
+        "--channel",
+        "abc",
+        "--override-channels",
+        "numpy",
+        "scipy",
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,19 +1,14 @@
-import sys
-
 from conda_pypi.main import run_conda_cli, run_conda_install
 
 
 def test_run_conda_cli(mocker):
-    mock = mocker.patch("conda_pypi.main.run_module")
+    mock = mocker.patch("conda_pypi.main.main_subshell")
 
-    old_sys_argv = sys.argv
-    run_conda_cli()
+    args = ["install", "--prefix", "/path/to/prefix"]
+    run_conda_cli(*args)
 
     # Ensure conda module is called
-    mock.assert_called_once_with("conda", run_name="__main__")
-
-    # Ensure args are restored
-    assert sys.argv == old_sys_argv
+    mock.assert_called_once_with(*args)
 
 
 def test_run_conda_install_basic(mocker):


### PR DESCRIPTION
This PR adds the functionality for installing packages after they have been converted. Dependencies that are avilable on configured channels will be installed from those channels. Ones that are not available will be converted and added to a local `conda-pypi` channel and instlaled from there.

For example, consider the pypi package [`neptune-detectron2`](https://pypi.org/project/neptune-detectron2/). It can be installed with the command (running from the pixi development environment):

```
$ pixi run conda pypi install neptune-detectron2

. . .
Solving environment: done

## Package Plan ##

  environment location: /home/sophia/projects/conda-pypi/.pixi/envs/test-py311

  added / updated specs:
    - neptune-detectron2


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    aom-3.6.0                  |       h6a678d5_0         2.8 MB
    ca-certificates-2025.9.9   |       h06a4308_0         127 KB
    cairo-1.18.4               |       h44eff21_0         728 KB
    dav1d-1.2.1                |       h5eee18b_0         823 KB
    fontconfig-2.15.0          |       h7e30c49_1         259 KB  conda-forge
    freetype-2.13.3            |       h4a9f257_0         686 KB
    fribidi-1.0.10             |       h7b6447c_0         103 KB
    fvcore-0.1.5.post20221213  |     pyhd8ed1ab_0          59 KB  conda-forge
    graphite2-1.3.14           |       h295c915_1          97 KB
    harfbuzz-10.4.0            |       h76408a6_0         1.6 MB  conda-forge
    jpeg-9f                    |       h5ce9db8_0         242 KB
    lcms2-2.16                 |       h92b89f2_1         269 KB
    lerc-4.0.0                 |       h6a678d5_0         261 KB
    libavif-1.1.1              |       h5eee18b_0         144 KB
    libdeflate-1.22            |       h5eee18b_0          68 KB
    libglib-2.84.2             |       h37c7471_0         1.7 MB
    liblzma-devel-5.8.1        |       hb9d3cd8_2         430 KB  conda-forge
    libpng-1.6.39              |       h5eee18b_0         304 KB
    libtiff-4.7.0              |       hde9077f_0         447 KB
    libwebp-base-1.3.2         |       h5eee18b_1         425 KB
    libxcb-1.17.0              |       h9b100fa_0         430 KB
    neptune-detectron2-1.0.0   |           pypi_0          14 KB  file:///home/sophia/.local/share/conda-pypi
    numpy-1.23.5               |  py311h7d28db0_0         6.5 MB  conda-forge
    openjpeg-2.5.2             |       h0d4d230_1         373 KB
    pcre2-10.42                |       hebb0a14_1         1.3 MB
    pillow-11.3.0              |  py311hb1c3d2d_0         994 KB
    pixman-0.46.4              |       h7934f7d_0         1.9 MB
    portalocker-3.0.0          |  py311h06a4308_0          44 KB
    pthread-stubs-0.3          |       h0ce48e5_1           5 KB
    tabulate-0.9.0             |  py311h06a4308_0          70 KB
    termcolor-2.1.0            |  py311h06a4308_0          12 KB
    xorg-libx11-1.8.12         |       h9b100fa_1         895 KB
    xorg-libxau-1.0.12         |       h9b100fa_0          13 KB
    xorg-libxdmcp-1.1.5        |       h9b100fa_0          19 KB
    xorg-libxext-1.3.6         |       h9b100fa_0          49 KB
    xorg-libxrender-0.9.12     |       h9b100fa_0          31 KB
    xorg-xorgproto-2024.1      |       h5eee18b_1         580 KB
    xz-5.8.1                   |       hbcc6ac9_2          23 KB  conda-forge
    xz-gpl-tools-5.8.1         |       hbcc6ac9_2          33 KB  conda-forge
    xz-tools-5.8.1             |       hb9d3cd8_2          94 KB  conda-forge
    yacs-0.1.8                 |  py311h06a4308_0          39 KB
    zlib-1.3.1                 |       hb9d3cd8_2          90 KB  conda-forge
    ------------------------------------------------------------
                                           Total:        24.9 MB

The following NEW packages will be INSTALLED:

  aom                pkgs/main/linux-64::aom-3.6.0-h6a678d5_0 
  cairo              pkgs/main/linux-64::cairo-1.18.4-h44eff21_0 
  dav1d              pkgs/main/linux-64::dav1d-1.2.1-h5eee18b_0 
  fontconfig         conda-forge/linux-64::fontconfig-2.15.0-h7e30c49_1 
  freetype           pkgs/main/linux-64::freetype-2.13.3-h4a9f257_0 
  fribidi            pkgs/main/linux-64::fribidi-1.0.10-h7b6447c_0 
  fvcore             conda-forge/noarch::fvcore-0.1.5.post20221213-pyhd8ed1ab_0 
  graphite2          pkgs/main/linux-64::graphite2-1.3.14-h295c915_1 
  harfbuzz           conda-forge/linux-64::harfbuzz-10.4.0-h76408a6_0 
  jpeg               pkgs/main/linux-64::jpeg-9f-h5ce9db8_0 
  lcms2              pkgs/main/linux-64::lcms2-2.16-h92b89f2_1 
  lerc               pkgs/main/linux-64::lerc-4.0.0-h6a678d5_0 
  libavif            pkgs/main/linux-64::libavif-1.1.1-h5eee18b_0 
  libdeflate         pkgs/main/linux-64::libdeflate-1.22-h5eee18b_0 
  libglib            pkgs/main/linux-64::libglib-2.84.2-h37c7471_0 
  liblzma-devel      conda-forge/linux-64::liblzma-devel-5.8.1-hb9d3cd8_2 
  libpng             pkgs/main/linux-64::libpng-1.6.39-h5eee18b_0 
  libtiff            pkgs/main/linux-64::libtiff-4.7.0-hde9077f_0 
  libwebp-base       pkgs/main/linux-64::libwebp-base-1.3.2-h5eee18b_1 
  libxcb             pkgs/main/linux-64::libxcb-1.17.0-h9b100fa_0 
  neptune-detectron2 conda-pypi/noarch::neptune-detectron2-1.0.0-pypi_0 
  openjpeg           pkgs/main/linux-64::openjpeg-2.5.2-h0d4d230_1 
  pcre2              pkgs/main/linux-64::pcre2-10.42-hebb0a14_1 
  pillow             pkgs/main/linux-64::pillow-11.3.0-py311hb1c3d2d_0 
  pixman             pkgs/main/linux-64::pixman-0.46.4-h7934f7d_0 
  portalocker        pkgs/main/linux-64::portalocker-3.0.0-py311h06a4308_0 
  pthread-stubs      pkgs/main/linux-64::pthread-stubs-0.3-h0ce48e5_1 
  tabulate           pkgs/main/linux-64::tabulate-0.9.0-py311h06a4308_0 
  termcolor          pkgs/main/linux-64::termcolor-2.1.0-py311h06a4308_0 
  xorg-libx11        pkgs/main/linux-64::xorg-libx11-1.8.12-h9b100fa_1 
  xorg-libxau        pkgs/main/linux-64::xorg-libxau-1.0.12-h9b100fa_0 
  xorg-libxdmcp      pkgs/main/linux-64::xorg-libxdmcp-1.1.5-h9b100fa_0 
  xorg-libxext       pkgs/main/linux-64::xorg-libxext-1.3.6-h9b100fa_0 
  xorg-libxrender    pkgs/main/linux-64::xorg-libxrender-0.9.12-h9b100fa_0 
  xorg-xorgproto     pkgs/main/linux-64::xorg-xorgproto-2024.1-h5eee18b_1 
  xz                 conda-forge/linux-64::xz-5.8.1-hbcc6ac9_2 
  xz-gpl-tools       conda-forge/linux-64::xz-gpl-tools-5.8.1-hbcc6ac9_2 
  xz-tools           conda-forge/linux-64::xz-tools-5.8.1-hb9d3cd8_2 
  yacs               pkgs/main/linux-64::yacs-0.1.8-py311h06a4308_0 
  zlib               conda-forge/linux-64::zlib-1.3.1-hb9d3cd8_2 

The following packages will be UPDATED:

  ca-certificates    conda-forge/noarch::ca-certificates-2~ --> pkgs/main/linux-64::ca-certificates-2025.9.9-h06a4308_0 

The following packages will be DOWNGRADED:

  numpy                               2.3.3-py311h2e04523_0 --> 1.23.5-py311h7d28db0_0 



Downloading and Extracting Packages:
                                                                                                     
Preparing transaction: done                                                                          
Verifying transaction: done                                                                          
Executing transaction: done      
```

Notice the pypi package is not avilable on the configured conda channels so is installed from the local `conda-pypi` channel:
```
  neptune-detectron2 conda-pypi/noarch::neptune-detectron2-1.0.0-pypi_0 
```

And all other dependencies are avilable on default or conda-forge, so are installed from there.

Note: this does not work for:
- editable packages
- packages on pypi that do not have `.whl` files uploaded
- normalizing pypi package name

addresses: https://github.com/conda-incubator/conda-pypi/issues/95