### PR TITLE
Don't use mapfile in canary upload for improved macOS compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,22 +121,27 @@ jobs:
           && github.ref_name == 'main'
         shell: bash
         run: |
-          search_root="$CONDA_BLD_PATH/${{ matrix.subdir }}"
-          if [[ ! -d "$search_root" ]]; then
-            echo "Expected build output directory $search_root not found" >&2
+          SEARCH_ROOT="$CONDA_BLD_PATH/${{ matrix.subdir }}"
+          if [[ ! -d "$SEARCH_ROOT" ]]; then
+            echo "Expected build output directory $SEARCH_ROOT not found" >&2
             exit 1
           fi
 
-          mapfile -t packages < <(find "$search_root" -type f \
-            \( -name "${PACKAGE_NAME}-*.conda" -o -name "${PACKAGE_NAME}-*.tar.bz2" \) | sort)
+          PACKAGES=(
+            $(
+              find "$SEARCH_ROOT" -type f \
+              \( -name "${PACKAGE_NAME}-*.conda" -o -name "${PACKAGE_NAME}-*.tar.bz2" \) \
+              -print | sort
+            )
+          )
 
-          if [[ ${#packages[@]} -eq 0 ]]; then
-            echo "No conda packages found in $search_root" >&2
+          if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+            echo "No conda packages found in $SEARCH_ROOT" >&2
             exit 1
           fi
 
           printf 'Uploading packages to %s/label/%s:\n' "$ANACONDA_ORG_CHANNEL" "$ANACONDA_ORG_LABEL"
-          printf '  %s\n' "${packages[@]}"
+          printf '  %s\n' "${PACKAGES[@]}"
           pixi run --environment build \
             anaconda \
             upload \
@@ -145,4 +150,4 @@ jobs:
             --no-progress \
             --user "$ANACONDA_ORG_CHANNEL" \
             --label "$ANACONDA_ORG_LABEL" \
-            "${packages[@]}"
+            "${PACKAGES[@]}"


### PR DESCRIPTION
Refactors package upload script to use consistent variable naming and improve readability.

Follow-up to #122 which used `mapfile` which isn't existent on macOS 🤦🏻.

Fix #127.