### PR TITLE
Suppress output from solve

### DIFF
--- a/conda_pypi/convert_tree.py
+++ b/conda_pypi/convert_tree.py
@@ -29,6 +29,7 @@ from unearth import PackageFinder
 from conda_pypi.build import build_conda
 from conda_pypi.downloader import find_and_fetch, get_package_finder
 from conda_pypi.index import update_index
+from conda_pypi.utils import SuppressOutput
 
 log = logging.getLogger(__name__)
 
@@ -154,7 +155,8 @@ class ConvertTree:
             while len(fetched_packages) < max_attempts and attempts < max_attempts:
                 attempts += 1
                 try:
-                    changes = solver.solve_for_diff()
+                    with SuppressOutput():
+                        changes = solver.solve_for_diff()
                     break
                 except conda.exceptions.PackagesNotFoundError as e:
                     missing_packages = set(e._kwargs["packages"])

--- a/conda_pypi/utils.py
+++ b/conda_pypi/utils.py
@@ -39,7 +39,7 @@ def pypi_spec_variants(spec_str: str) -> Iterator[str]:
 class SuppressOutput:
     def __enter__(self):
         self._original_stdout = sys.stdout
-        sys.stdout = open(os.devnull, 'w')
+        sys.stdout = open(os.devnull, "w")
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         sys.stdout.close()

--- a/conda_pypi/utils.py
+++ b/conda_pypi/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import sys
+
 from logging import getLogger
 from pathlib import Path
 from typing import Iterator
@@ -32,3 +34,13 @@ def pypi_spec_variants(spec_str: str) -> Iterator[str]:
         if name_variant not in seen:  # only yield if actually different
             yield str(MatchSpec(spec, name=name_variant))
             seen.add(name_variant)
+
+
+class SuppressOutput:
+    def __enter__(self):
+        self._original_stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout.close()
+        sys.stdout = self._original_stdout


### PR DESCRIPTION
This change suppress the output from running conda solves during the conversion stage.

```
$ pixi run conda pypi install scipy --override-channels
Channels:
 - file:///home/sophia/.local/share/conda-pypi
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/sophia/projects/conda-pypi/.pixi/envs/default

  added / updated specs:
    - scipy


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    scipy-1.16.2               |           pypi_0        28.7 MB  file:///home/sophia/.local/share/conda-pypi
    ------------------------------------------------------------
                                           Total:        28.7 MB

The following NEW packages will be INSTALLED:

  scipy              conda-pypi/noarch::scipy-1.16.2-pypi_0 


Proceed ([y]/n)? 
```

One downside of this approach is that, for packages with lots of dependencies, the user will not have any feedback in the cli until the whole package conversion process is finished. For example, try something like `pixi run conda pypi install neptune-detectron2`.

fixes: https://github.com/conda-incubator/conda-pypi/issues/97
alternative to https://github.com/conda-incubator/conda-pypi/pull/132